### PR TITLE
Basement for view binding.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,6 +32,9 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    viewBinding {
+        enabled = true
+    }
 }
 
 dependencies {

--- a/app/src/main/java/com/denis/mvi_recyclerview_coil_hilt_espresso_junit/MainActivity.kt
+++ b/app/src/main/java/com/denis/mvi_recyclerview_coil_hilt_espresso_junit/MainActivity.kt
@@ -2,13 +2,17 @@ package com.denis.mvi_recyclerview_coil_hilt_espresso_junit
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import com.denis.mvi_recyclerview_coil_hilt_espresso_junit.databinding.MainActivityBinding
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
 
+    private lateinit var binding: MainActivityBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.main_activity)
+        binding = MainActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
     }
 }

--- a/app/src/main/java/com/denis/mvi_recyclerview_coil_hilt_espresso_junit/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/denis/mvi_recyclerview_coil_hilt_espresso_junit/ui/main/MainFragment.kt
@@ -1,13 +1,21 @@
 package com.denis.mvi_recyclerview_coil_hilt_espresso_junit.ui.main
 
+import android.os.Bundle
+import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.denis.mvi_recyclerview_coil_hilt_espresso_junit.R
+import com.denis.mvi_recyclerview_coil_hilt_espresso_junit.databinding.MainFragmentBinding
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainFragment : Fragment(R.layout.main_fragment) {
 
+    private lateinit var binding: MainFragmentBinding
     private val viewModel by viewModels<MainViewModel>()
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding = MainFragmentBinding.bind(view)
+    }
 }


### PR DESCRIPTION
Why view binding:

1. Easy to get access to any view
2. Works faster then findViewById()
3. Reducing the number of internal variables inside classes