### PR TITLE
Domain layer convert data from repository data model to presentation data layer

### DIFF
--- a/app/src/main/java/com/denis/mvi_recyclerview_coil_hilt_espresso_junit/data/RepositoryData.kt
+++ b/app/src/main/java/com/denis/mvi_recyclerview_coil_hilt_espresso_junit/data/RepositoryData.kt
@@ -1,5 +1,9 @@
 package com.denis.mvi_recyclerview_coil_hilt_espresso_junit.data
 
 data class RepositoryData(
-    val someValue: Boolean
+    val albumId: Int,
+    val id: Int,
+    val title: String,
+    val url: String,
+    val thumbnailUrl: String,
 )

--- a/app/src/main/java/com/denis/mvi_recyclerview_coil_hilt_espresso_junit/domain/Converter.kt
+++ b/app/src/main/java/com/denis/mvi_recyclerview_coil_hilt_espresso_junit/domain/Converter.kt
@@ -6,6 +6,12 @@ import javax.inject.Inject
 
 class Converter @Inject constructor() {
     fun convertFromRepositoryToPresentation(repositoryData: RepositoryData): PresentationData {
-        return PresentationData(true)
+        return PresentationData(
+            albumId = repositoryData.albumId,
+            id = repositoryData.id,
+            title = repositoryData.title,
+            url = repositoryData.url,
+            thumbnailUrl = repositoryData.thumbnailUrl,
+        )
     }
 }

--- a/app/src/main/java/com/denis/mvi_recyclerview_coil_hilt_espresso_junit/presentation/PresentationData.kt
+++ b/app/src/main/java/com/denis/mvi_recyclerview_coil_hilt_espresso_junit/presentation/PresentationData.kt
@@ -1,5 +1,16 @@
 package com.denis.mvi_recyclerview_coil_hilt_espresso_junit.presentation
 
+/**
+"albumId": 1,
+"id": 1,
+"title": "accusamus beatae ad facilis cum similique qui sunt",
+"url": "https://via.placeholder.com/600/92c952",
+"thumbnailUrl": "https://via.placeholder.com/150/92c952"
+ */
 data class PresentationData(
-    val someValue: Boolean
+    val albumId: Int,
+    val id: Int,
+    val title: String,
+    val url: String,
+    val thumbnailUrl: String,
 )

--- a/app/src/test/java/com/denis/mvi_recyclerview_coil_hilt_espresso_junit/domain/ConverterTest.kt
+++ b/app/src/test/java/com/denis/mvi_recyclerview_coil_hilt_espresso_junit/domain/ConverterTest.kt
@@ -1,0 +1,153 @@
+package com.denis.mvi_recyclerview_coil_hilt_espresso_junit.domain
+
+import com.denis.mvi_recyclerview_coil_hilt_espresso_junit.data.RepositoryData
+import org.junit.Assert.*
+import org.junit.Test
+
+class ConverterTest {
+
+    private val subject = Converter()
+
+    @Test
+    fun `when albumId is negative should create presentation object`() {
+        val sourceValue = RepositoryData(
+            albumId = -100,
+            id = 1,
+            title = "",
+            url = "",
+            thumbnailUrl = "",
+        )
+        val result = subject.convertFromRepositoryToPresentation(sourceValue)
+        assertEquals(-100, result.albumId)
+    }
+
+    @Test
+    fun `when albumId is minimal int value should create presentation object`() {
+        val sourceValue = RepositoryData(
+            albumId = Int.MIN_VALUE,
+            id = 1,
+            title = "",
+            url = "",
+            thumbnailUrl = "",
+        )
+        val result = subject.convertFromRepositoryToPresentation(sourceValue)
+        assertEquals(Int.MIN_VALUE, result.albumId)
+    }
+
+    @Test
+    fun `when albumId is positive int value should create presentation object`() {
+        val sourceValue = RepositoryData(
+            albumId = 1000,
+            id = 1,
+            title = "",
+            url = "",
+            thumbnailUrl = "",
+        )
+        val result = subject.convertFromRepositoryToPresentation(sourceValue)
+        assertEquals(1000, result.albumId)
+    }
+
+    @Test
+    fun `when albumId is maximal int value should create presentation object`() {
+        val sourceValue = RepositoryData(
+            albumId = Int.MAX_VALUE,
+            id = 1,
+            title = "",
+            url = "",
+            thumbnailUrl = "",
+        )
+        val result = subject.convertFromRepositoryToPresentation(sourceValue)
+        assertEquals(Int.MAX_VALUE, result.albumId)
+    }
+
+    @Test
+    fun `when id is negative should create presentation object`() {
+        val sourceValue = RepositoryData(
+            albumId = 1,
+            id = -100,
+            title = "",
+            url = "",
+            thumbnailUrl = "",
+        )
+        val result = subject.convertFromRepositoryToPresentation(sourceValue)
+        assertEquals(-100, result.id)
+    }
+
+    @Test
+    fun `when id is minimal int value should create presentation object`() {
+        val sourceValue = RepositoryData(
+            albumId = 1,
+            id = Int.MIN_VALUE,
+            title = "",
+            url = "",
+            thumbnailUrl = "",
+        )
+        val result = subject.convertFromRepositoryToPresentation(sourceValue)
+        assertEquals(Int.MIN_VALUE, result.id)
+    }
+
+    @Test
+    fun `when id is positive int value should create presentation object`() {
+        val sourceValue = RepositoryData(
+            albumId = 1,
+            id = 1000,
+            title = "",
+            url = "",
+            thumbnailUrl = "",
+        )
+        val result = subject.convertFromRepositoryToPresentation(sourceValue)
+        assertEquals(1000, result.id)
+    }
+
+    @Test
+    fun `when id is maximal int value should create presentation object`() {
+        val sourceValue = RepositoryData(
+            albumId = 1,
+            id = Int.MAX_VALUE,
+            title = "",
+            url = "",
+            thumbnailUrl = "",
+        )
+        val result = subject.convertFromRepositoryToPresentation(sourceValue)
+        assertEquals(Int.MAX_VALUE, result.id)
+    }
+
+    @Test
+    fun `when title contains special symbols should create presentation object`() {
+        val sourceValue = RepositoryData(
+            albumId = 1,
+            id = 1,
+            title = "±!@#$%ˆ&*()_+}{|:?><˜\"",
+            url = "",
+            thumbnailUrl = "",
+        )
+        val result = subject.convertFromRepositoryToPresentation(sourceValue)
+        assertEquals("±!@#$%ˆ&*()_+}{|:?><˜\"", result.title)
+    }
+
+    @Test
+    fun `when url contains special symbols should create presentation object`() {
+        val sourceValue = RepositoryData(
+            albumId = 1,
+            id = 1,
+            title = "",
+            url = "±!@#$%ˆ&*()_+}{|:?><˜\"",
+            thumbnailUrl = "",
+        )
+        val result = subject.convertFromRepositoryToPresentation(sourceValue)
+        assertEquals("±!@#$%ˆ&*()_+}{|:?><˜\"", result.url)
+    }
+
+    @Test
+    fun `when thumbnailUrl contains special symbols should create presentation object`() {
+        val sourceValue = RepositoryData(
+            albumId = 1,
+            id = 1,
+            title = "",
+            url = "",
+            thumbnailUrl = "±!@#$%ˆ&*()_+}{|:?><˜\"",
+        )
+        val result = subject.convertFromRepositoryToPresentation(sourceValue)
+        assertEquals("±!@#$%ˆ&*()_+}{|:?><˜\"", result.thumbnailUrl)
+    }
+}


### PR DESCRIPTION
As we have a possibility to get items one by one, we can reduce traffic for the user by requesting only the needed number of items. For this purpose, I want to use Pagination. It helps me to postpone this work(control of updates and getting new items) to external library. This commit prepare network and presentation data models for upcoming conversion from one layer to another.